### PR TITLE
Update RemapGenes.R

### DIFF
--- a/util/RemapGenes.R
+++ b/util/RemapGenes.R
@@ -5,14 +5,14 @@ library(Matrix)
 
 mapReadGTF <- function(file,hasColumnNames){
   
-  regexPattern = "gene_id \"(ENSMUSG[0-9.]+)\";.+gene_name \"([[:print:]]+?)\"; .+"
+  regxPattern = "gene_id \"(ENSMUSG[0-9.]+)\";.+gene_name \"([[:print:]]+?)\"; .+"
   cnames = hasColumnNames
   if (!cnames) cnames=c("Chromosome","Source","Feature","Start","End","Score","Strand","Frame","Attributes") 
   
   gtf <- read_tsv(file,col_names = cnames, col_types = "ccccccccc", comment = '#') %>% 
     mutate(
-      gene_id    = gsub(regexPattern,"\\1",Attributes),
-      gene_names = gsub(regexPattern,"\\2",Attributes) 
+      gene_id    = gsub(regxPattern,"\\1",Attributes),
+      gene_names = gsub(regxPattern,"\\2",Attributes) 
     ) %>% 
     select(gene_id,gene_names) %>% 
     distinct() %>%
@@ -21,7 +21,7 @@ mapReadGTF <- function(file,hasColumnNames){
     # function to make the gene names unique.  We're going to do the same.
     mutate(gene_names=make.unique(gene_names))
   
-  return(gtf)
+    return(gtf)
 }
 
 mapGenes <- function(fromGenome,ToGenome,count_matrix){

--- a/util/RemapGenes.R
+++ b/util/RemapGenes.R
@@ -5,13 +5,14 @@ library(Matrix)
 
 mapReadGTF <- function(file,hasColumnNames){
   
+  regexPattern = "gene_id \"(ENSMUSG[0-9.]+)\";.+gene_name \"([[:print:]]+?)\"; .+"
   cnames = hasColumnNames
   if (!cnames) cnames=c("Chromosome","Source","Feature","Start","End","Score","Strand","Frame","Attributes") 
   
   gtf <- read_tsv(file,col_names = cnames, col_types = "ccccccccc", comment = '#') %>% 
     mutate(
-      gene_id    = gsub("gene_id \"(ENSMUSG\\d+)\";.+","\\1",Attributes),
-      gene_names = gsub(".+ gene_name \"([[:print:]]+?)\"; .+","\\1",Attributes) 
+      gene_id    = gsub(regexPattern,"\\1",Attributes),
+      gene_names = gsub(regexPattern,"\\2",Attributes) 
     ) %>% 
     select(gene_id,gene_names) %>% 
     distinct() %>%

--- a/util/RemapGenes.R
+++ b/util/RemapGenes.R
@@ -2,7 +2,6 @@ library(tidyverse)
 library(Seurat)
 library(Matrix)
 
-
 mapReadGTF <- function(file,hasColumnNames){
   
   regxPattern = "gene_id \"(ENSMUSG[0-9.]+)\";.+gene_name \"([[:print:]]+?)\"; .+"


### PR DESCRIPTION
1. Fix bug in `mapGenes` (countMatrix does not exist)

2. Make `mapReadGTF` more versatile (ignores comment lines and parser regex is more robust), so now it works on the latest 10x cellranger `refdata-gex-mm10-2020-A/genes/genes.gtf`)

Previously, the lack of support for ignoring comments lead to the error
```
Error in `mutate_cols()`:                                                                                                                                                                                                         
! Problem with `mutate()` column `gene_id`.
ℹ `gene_id = gsub(regxPattern, "\\1", Attributes)`.
x object 'Attributes' not found
Caused by error in `is.factor()`:
! object 'Attributes' not found
Run `rlang::last_error()` to see where the error occurred.
```

The previous regex parsers led to issues in the data frame being set up properly (because one cannot guarantee the "gene_source" attribute will immediately follow the gene_name)